### PR TITLE
feat: auto-send 15-day digest review email with OKN Updates sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ Set via the Cloudflare Pages dashboard or `wrangler pages secret put`:
 | `B2_ENDPOINT` | `s3.eu-central-003.backblazeb2.com` |
 | `B2_BUCKET` | `okn-media-archive` |
 | `RESEND_API_KEY` | API key for digest review/final email delivery |
-| `WEEKLY_DIGEST_FROM` | Verified sender, e.g. `OKN Digest <digest@updates.cybersystema.com>` |
+| `WEEKLY_DIGEST_FROM` | Verified sender address — a plain address, no angle brackets, default `okn@updates.cybersystema.com` |
+| `WEEKLY_DIGEST_FROM_NAME` | Display name shown in inboxes, default `OKN Updates`. Combined with the address into a proper `Name <address>` header automatically; recipients only see the name |
 | `WEEKLY_DIGEST_REVIEW_RECIPIENTS` | Your private review inbox or inboxes |
 | `WEEKLY_DIGEST_RECIPIENTS` | Final recipient list for the approved digest |
 | `WEEKLY_DIGEST_SITE_URL` | Source site, default `https://orthodoxkorea.org` |
@@ -201,10 +202,10 @@ The digest workflow now lives inside the private OKN admin panel. There is no Gi
 
 ### Optional Cloudflare-native cron draft trigger
 
-An optional separate Cloudflare Worker can create the draft on a schedule without sending email and without switching the Pages project into advanced mode.
+An optional separate Cloudflare Worker generates the draft on a schedule and emails it to the review recipients automatically — no manual step and no switching the Pages project into advanced mode. The review email uses the same `[READY FOR REVIEW]` template as the admin button; the **final** email still requires manual approval in the admin UI.
 
 Files:
-- `functions/api/internal/digest-draft.js` — secret-protected Pages endpoint that only creates the draft.
+- `functions/api/internal/digest-draft.js` — secret-protected Pages endpoint that creates the draft and sends the review email to `WEEKLY_DIGEST_REVIEW_RECIPIENTS`.
 - `workers/digest-cron.mjs` — scheduled Worker that calls the Pages endpoint.
 - `wrangler.digest-cron.jsonc` — Worker config with the 1st and 16th at `00:15 UTC` cron.
 
@@ -220,7 +221,7 @@ Deploy the scheduled Worker separately from the Pages project:
 npx wrangler deploy -c wrangler.digest-cron.jsonc
 ```
 
-The cron path is idempotent for a given digest window: if a draft for the current window already exists, it returns the existing draft instead of overwriting editorial changes.
+The cron path is idempotent for a given digest window: if a draft for the current window already exists, it returns the existing draft instead of overwriting editorial changes. The review email is sent at most once per window — a draft that already records `reviewSentAt` is not re-sent, and a draft created on an earlier run that failed to email is retried on the next call.
 
 ### Local script
 

--- a/functions/_lib/digest.js
+++ b/functions/_lib/digest.js
@@ -3,6 +3,12 @@ const DEFAULT_LOOKBACK_DAYS = 15;
 const MIN_LOOKBACK_DAYS = 1;
 const MAX_LOOKBACK_DAYS = 365;
 export const DIGEST_PREFIX = 'digest:';
+const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+const REVIEW_SUBJECT_PREFIX = '[READY FOR REVIEW]';
+const DEFAULT_FROM_NAME = 'OKN Updates';
+const DEFAULT_FROM_ADDRESS = 'okn@updates.cybersystema.com';
+// RFC 5322 "specials": a display name containing any of these must be quoted.
+const RFC5322_SPECIALS = /[()<>@,;:\\".[\]]/;
 
 export function json(payload, status = 200) {
   return Response.json(payload, {
@@ -88,6 +94,96 @@ export function parseRecipients(input) {
     .map((v) => v.trim())
     .filter(Boolean)
     .filter((value, index, arr) => arr.indexOf(value) === index);
+}
+
+export function getReviewRecipients(env) {
+  return parseRecipients(String(env.WEEKLY_DIGEST_REVIEW_RECIPIENTS || ''));
+}
+
+function sanitizeDisplayName(name) {
+  return String(name || '')
+    .replace(/^"+|"+$/g, '')
+    .replace(/[<>]/g, '')
+    .replace(/[\r\n\t]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function sanitizeAddress(address) {
+  return String(address || '').replace(/[<>\s]/g, '').trim();
+}
+
+function quoteDisplayName(name) {
+  if (!RFC5322_SPECIALS.test(name)) return name;
+  return `"${name.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+// Builds a professional sender from a plain display name and a plain address.
+// Operators configure WEEKLY_DIGEST_FROM as a bare address (no angle brackets)
+// plus an optional WEEKLY_DIGEST_FROM_NAME; the angle brackets exist only in the
+// raw header and are never shown to recipients. A legacy "Name <addr>" value is
+// accepted and re-normalized.
+export function resolveFromAddress(env) {
+  const raw = String(env.WEEKLY_DIGEST_FROM || '').trim();
+  const bracketed = raw.match(/^(.*?)<([^>]+)>\s*$/);
+  const parsed = sanitizeAddress(bracketed ? bracketed[2] : raw);
+
+  let address;
+  if (!raw) {
+    address = DEFAULT_FROM_ADDRESS; // unset → fall back to the known OKN sender
+  } else if (parsed.includes('@')) {
+    address = parsed;
+  } else {
+    throw new Error('WEEKLY_DIGEST_FROM does not contain a valid email address.');
+  }
+
+  const embeddedName = bracketed ? sanitizeDisplayName(bracketed[1]) : '';
+  const name = sanitizeDisplayName(env.WEEKLY_DIGEST_FROM_NAME) || embeddedName || DEFAULT_FROM_NAME;
+  return name ? `${quoteDisplayName(name)} <${address}>` : address;
+}
+
+export async function sendDigestEmail(env, draft, recipients, subjectPrefix) {
+  const from = resolveFromAddress(env);
+  const apiKey = String(env.RESEND_API_KEY || '').trim();
+  if (!apiKey) throw new Error('RESEND_API_KEY is not configured.');
+
+  return sendWithResend({
+    apiKey,
+    from,
+    to: recipients,
+    subject: `${String(subjectPrefix || '').trim()} ${draft.subject}`.trim(),
+    text: draft.text,
+    html: draft.html,
+  });
+}
+
+async function sendWithResend({ apiKey, from, to, subject, text, html }) {
+  const response = await fetch(RESEND_ENDPOINT, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ from, to, subject, text, html }),
+  });
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    throw new Error(`Resend API failed (${response.status}): ${detail.slice(0, 500)}`);
+  }
+  return response.json();
+}
+
+// Sends the review email to WEEKLY_DIGEST_REVIEW_RECIPIENTS and records delivery
+// on the draft. Shared by the admin "send review" button and the scheduled cron.
+export async function sendReviewEmail(ns, env, draft) {
+  const reviewRecipients = getReviewRecipients(env);
+  if (!reviewRecipients.length) {
+    throw new Error('WEEKLY_DIGEST_REVIEW_RECIPIENTS is not configured.');
+  }
+  const result = await sendDigestEmail(env, draft, reviewRecipients, REVIEW_SUBJECT_PREFIX);
+  draft.reviewSentAt = new Date().toISOString();
+  draft.updatedAt = draft.reviewSentAt;
+  draft.status = 'review-sent';
+  draft.reviewMessageId = result?.id || '';
+  await saveDraft(ns, draft);
+  return result;
 }
 
 function digestId(fromMs, toMs) {

--- a/functions/api/admin/digest.js
+++ b/functions/api/admin/digest.js
@@ -14,9 +14,9 @@ import {
   parseRecipients,
   requireDraft,
   saveDraft,
+  sendDigestEmail,
+  sendReviewEmail,
 } from '../../_lib/digest.js';
-
-const RESEND_ENDPOINT = 'https://api.resend.com/emails';
 
 export async function onRequestGet(context) {
   const { request, env } = context;
@@ -99,16 +99,7 @@ export async function onRequestPost(context) {
 
     if (action === 'digest.sendReview') {
       const draft = await requireDraft(ns, body.id);
-      const reviewRecipients = parseRecipients(String(env.WEEKLY_DIGEST_REVIEW_RECIPIENTS || ''));
-      if (!reviewRecipients.length) {
-        return json({ ok: false, error: 'WEEKLY_DIGEST_REVIEW_RECIPIENTS is not configured.' }, 400);
-      }
-      const result = await sendDigestEmail(env, draft, reviewRecipients, '[READY FOR REVIEW]');
-      draft.reviewSentAt = new Date().toISOString();
-      draft.updatedAt = draft.reviewSentAt;
-      draft.status = 'review-sent';
-      draft.reviewMessageId = result?.id || '';
-      await saveDraft(ns, draft);
+      const result = await sendReviewEmail(ns, env, draft);
       return json({ ok: true, draft, messageId: result?.id || null });
     }
 
@@ -190,33 +181,4 @@ function rebuildDraftContent(draft) {
   draft.subject = rebuilt.subject;
   draft.text = rebuilt.text;
   draft.html = rebuilt.html;
-}
-
-async function sendDigestEmail(env, draft, recipients, subjectPrefix) {
-  const from = String(env.WEEKLY_DIGEST_FROM || '').trim();
-  const apiKey = String(env.RESEND_API_KEY || '').trim();
-  if (!from) throw new Error('WEEKLY_DIGEST_FROM is not configured.');
-  if (!apiKey) throw new Error('RESEND_API_KEY is not configured.');
-
-  return sendWithResend({
-    apiKey,
-    from,
-    to: recipients,
-    subject: `${String(subjectPrefix || '').trim()} ${draft.subject}`.trim(),
-    text: draft.text,
-    html: draft.html,
-  });
-}
-
-async function sendWithResend({ apiKey, from, to, subject, text, html }) {
-  const response = await fetch(RESEND_ENDPOINT, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ from, to, subject, text, html }),
-  });
-  if (!response.ok) {
-    const detail = await response.text().catch(() => '');
-    throw new Error(`Resend API failed (${response.status}): ${detail.slice(0, 500)}`);
-  }
-  return response.json();
 }

--- a/functions/api/internal/digest-draft.js
+++ b/functions/api/internal/digest-draft.js
@@ -1,4 +1,10 @@
-import { createDigestDraftIfMissing, json } from '../../_lib/digest.js';
+import {
+  createDigestDraftIfMissing,
+  getDigestNamespace,
+  getReviewRecipients,
+  json,
+  sendReviewEmail,
+} from '../../_lib/digest.js';
 
 export async function onRequestPost(context) {
   const { request, env } = context;
@@ -9,10 +15,31 @@ export async function onRequestPost(context) {
 
   try {
     const result = await createDigestDraftIfMissing(env);
-    return json({ ok: true, created: result.created, draft: result.draft });
+    const review = await deliverReview(env, result.draft);
+    return json({ ok: true, created: result.created, review, draft: result.draft });
   } catch (error) {
     const status = String(error?.message || '').includes('No digest/admin KV configured') ? 503 : 500;
     return json({ ok: false, error: error?.message || 'Failed to create digest draft.' }, status);
+  }
+}
+
+// Auto-sends the review email so the scheduled cron delivers it without manual
+// intervention. Idempotent per window: a draft that already has reviewSentAt is
+// left untouched, while a draft created on an earlier run that failed to send is
+// retried here. A send failure is reported but does not discard the saved draft.
+async function deliverReview(env, draft) {
+  if (draft?.reviewSentAt) {
+    return { sent: false, skipped: 'already-sent', sentAt: draft.reviewSentAt };
+  }
+  if (!getReviewRecipients(env).length) {
+    return { sent: false, skipped: 'no-recipients' };
+  }
+
+  try {
+    const result = await sendReviewEmail(getDigestNamespace(env), env, draft);
+    return { sent: true, messageId: result?.id || null };
+  } catch (error) {
+    return { sent: false, error: error?.message || 'Failed to send review email.' };
   }
 }
 

--- a/tools/weekly-digest.mjs
+++ b/tools/weekly-digest.mjs
@@ -6,6 +6,10 @@ import { spawnSync } from 'node:child_process';
 const DEFAULT_SITE_URL = 'https://orthodoxkorea.org';
 const DEFAULT_LOOKBACK_DAYS = 15;
 const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+const DEFAULT_FROM_NAME = 'OKN Updates';
+const DEFAULT_FROM_ADDRESS = 'okn@updates.cybersystema.com';
+// RFC 5322 "specials": a display name containing any of these must be quoted.
+const RFC5322_SPECIALS = /[()<>@,;:\\".[\]]/;
 
 function env(name, fallback = '') {
   const value = process.env[name];
@@ -34,6 +38,45 @@ function parseRecipients(input) {
   }
 
   return unique;
+}
+
+function sanitizeDisplayName(name) {
+  return String(name || '')
+    .replace(/^"+|"+$/g, '')
+    .replace(/[<>]/g, '')
+    .replace(/[\r\n\t]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function sanitizeAddress(address) {
+  return String(address || '').replace(/[<>\s]/g, '').trim();
+}
+
+function quoteDisplayName(name) {
+  if (!RFC5322_SPECIALS.test(name)) return name;
+  return `"${name.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+// Mirrors resolveFromAddress() in functions/_lib/digest.js so the manual script
+// produces the same professional "Name <address>" sender as the production path.
+function resolveFromAddress(rawFrom, rawName) {
+  const raw = String(rawFrom || '').trim();
+  const bracketed = raw.match(/^(.*?)<([^>]+)>\s*$/);
+  const parsed = sanitizeAddress(bracketed ? bracketed[2] : raw);
+
+  let address;
+  if (!raw) {
+    address = DEFAULT_FROM_ADDRESS; // unset → fall back to the known OKN sender
+  } else if (parsed.includes('@')) {
+    address = parsed;
+  } else {
+    throw new Error('WEEKLY_DIGEST_FROM does not contain a valid email address.');
+  }
+
+  const embeddedName = bracketed ? sanitizeDisplayName(bracketed[1]) : '';
+  const name = sanitizeDisplayName(rawName) || embeddedName || DEFAULT_FROM_NAME;
+  return name ? `${quoteDisplayName(name)} <${address}>` : address;
 }
 
 function toBoolean(value) {
@@ -697,7 +740,7 @@ async function main() {
   const recipientsList = env('WEEKLY_DIGEST_RECIPIENTS', '');
   const recipientSingle = env('WEEKLY_DIGEST_RECIPIENT', '');
   const recipients = parseRecipients([recipientsList, recipientSingle].filter(Boolean).join(','));
-  const sender = env('WEEKLY_DIGEST_FROM', '');
+  const sender = resolveFromAddress(env('WEEKLY_DIGEST_FROM', ''), env('WEEKLY_DIGEST_FROM_NAME', ''));
   const resendApiKey = env('RESEND_API_KEY', '');
   const anthropicApiKey = env('ANTHROPIC_API_KEY', '');
   const maxSummarySentencesRaw = Number(env('WEEKLY_DIGEST_SUMMARY_MAX_SENTENCES', '3'));
@@ -717,10 +760,6 @@ async function main() {
   const invalidRecipients = recipients.filter((email) => !isValidEmail(email));
   if (invalidRecipients.length) {
     throw new Error(`Invalid recipient email(s): ${invalidRecipients.join(', ')}`);
-  }
-
-  if (!sender) {
-    throw new Error('WEEKLY_DIGEST_FROM is required.');
   }
 
   if (!dryRun && !resendApiKey) {
@@ -754,6 +793,7 @@ async function main() {
     console.log(`AI model: local ${summaryModel}`);
     console.log(`Summary overrides applied: ${summaryOverrides.length}`);
     console.log(`Summary sentences per post: ${maxSummarySentences}`);
+    console.log(`From: ${sender}`);
     console.log(`Recipients: ${recipients.join(', ')}`);
     console.log(`Subject: ${body.subject}`);
     console.log('Text preview:');


### PR DESCRIPTION
The scheduled digest cron previously only created the draft in KV; emailing the review was a manual admin step. The internal digest-draft endpoint now sends the review email to WEEKLY_DIGEST_REVIEW_RECIPIENTS automatically after creating a draft, reusing the same send path as the admin button.

- Move email-send logic into _lib/digest.js (sendDigestEmail, sendReviewEmail) so the admin button and cron path share one implementation.
- Auto-send is idempotent per window: a draft already carrying reviewSentAt is skipped; a draft created earlier that failed to send is retried on the next run.
- Add resolveFromAddress(): assembles a professional "OKN Updates <okn@updates.cybersystema.com>" sender from a plain name + address with RFC 5322 quoting, defaulting both. Recipients never see the angle brackets; legacy "Name <addr>" values are re-normalized.
- Apply the same sender normalization to tools/weekly-digest.mjs.
- Document the new env vars and updated cron behavior in README.

## Summary

Describe the change and why it is needed.

## Root Cause

What failed or what risk existed before this change?

## Scope

- In scope:
- Out of scope:

## Verification

List exact checks run and outcomes.

- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run autonomy:check`

## Risk and Rollback

- Risk level: low / medium / high
- Rollback steps:

## Operational Follow-up

- [ ] Runbook/docs updated if behavior changed
- [ ] New automation/workflow documented if added
